### PR TITLE
Replace RSSlink with RSSLink

### DIFF
--- a/layouts/partials/structure/head.html
+++ b/layouts/partials/structure/head.html
@@ -17,9 +17,9 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 
-    {{ if .RSSlink }}
-    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-    <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+    {{ if .RSSLink }}
+    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{ end }}
 
     <meta name="theme-color" content="{{ $.Site.Params.themeColor }}" />

--- a/layouts/partials/structure/head.no-amp.html
+++ b/layouts/partials/structure/head.no-amp.html
@@ -13,9 +13,9 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 
-    {{ if .RSSlink }}
-    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-    <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+    {{ if .RSSLink }}
+    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{ end }}
 
     <meta name="theme-color" content="{{ $.Site.Params.themeColor }}" />


### PR DESCRIPTION
The former is deprecated and now removed from Hugo. Note that the latter will also work in older versions of Hugo.