### PR TITLE
update sticky add custom-element

### DIFF
--- a/data/amp-modules.json
+++ b/data/amp-modules.json
@@ -43,7 +43,7 @@
   "amp-social-share" : "https://cdn.ampproject.org/v0/amp-social-share-0.1.js",
   "amp-soundcloud" : "https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js",
   "amp-springboard-player" : "https://cdn.ampproject.org/v0/amp-springboard-player-0.1.js",
-  "amp-sticky-ad-blae" : "https://cdn.ampproject.org/v0/amp-sticky-ad-1.0.js",
+  "amp-sticky-ad" : "https://cdn.ampproject.org/v0/amp-sticky-ad-1.0.js",
   "amp-twitter" : "https://cdn.ampproject.org/v0/amp-twitter-0.1.js",
   "amp-user-notification" : "https://cdn.ampproject.org/v0/amp-user-notification-0.1.js",
   "amp-vimeo" : "https://cdn.ampproject.org/v0/amp-vimeo-0.1.js",


### PR DESCRIPTION
The extension 'amp-sticky-ad' is referenced in version '0.1' which is a deprecated version. Please use a more recent version of this extension. This may become an error in the future.